### PR TITLE
Add draggable elements

### DIFF
--- a/about.html
+++ b/about.html
@@ -251,7 +251,7 @@
         </footer>
       </center>
     </div>
-    <div class="chat">
+    <div class="chat draggable">
       <iframe
         id="twitch-chat-embed"
         src="https://www.twitch.tv/embed/forsen/chat?parent=forsen.site"

--- a/contact.html
+++ b/contact.html
@@ -62,7 +62,7 @@
         <p id="randomLineContainer"></p>
       </div>
 
-      <div class="chat">
+      <div class="chat draggable">
         <iframe
           id="twitch-chat-embed"
           src="https://www.twitch.tv/embed/forsen/chat?parent=forsen.site"

--- a/css/styles.css
+++ b/css/styles.css
@@ -526,6 +526,16 @@ nav {
   margin-top: 15px;
 }
 
+/* Draggable elements like twitch chat */
+.draggable {
+  position: fixed;
+  z-index: 99;
+  cursor: move;
+}
+.draggable * {
+  cursor: unset;
+}
+
 .slide {
   position: absolute;
   left: 0px;
@@ -556,19 +566,17 @@ nav {
   /* align the hover element at the top of the container */
   width: 21%;
   /* adjust the width of the hover element as needed */
-  background-color: #ddd;
-  /* style the hover element, e.g., background-color, etc. */
   padding: 1rem;
+  padding-top: 2%;
   height: 38%;
+  /* style the hover element, e.g., background-color, etc. */
+  background-color: #ddd;
   background: rgba(255, 255, 255, 0.33);
   border-radius: 16px;
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(5.6px);
   -webkit-backdrop-filter: blur(5.6px);
   border: 1px solid rgba(255, 255, 255, 0.3);
-  padding-top: 2%;
-  margin-left: 1rem;
-  /* add some space between the main content and the hover element */
 }
 
 @media screen and (max-width: 600px) {

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         </button>
         <p id="randomLineContainer"></p>
       </div>
-      <div class="chat">
+      <div class="chat draggable">
         <iframe
           id="twitch-chat-embed"
           src="https://www.twitch.tv/embed/forsen/chat?parent=forsen.site"

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,55 @@
 document.addEventListener('DOMContentLoaded', function () {
+  /**
+   * Draggable elements (like twitch chat)
+   *
+   * Hint: want to add another draggable?
+   * Add "draggable" property and "draggable" class to an element
+   */
+  const draggables = document.getElementsByClassName('draggable');
+  for (const node of draggables) {
+    const nodeRelativeOffset = { x: 0, y: 0 };
+    const nodeStartingPosition = { x: 0, y: 0 };
+
+    // enable html5 interactivity:
+    node.draggable = true;
+
+    node.addEventListener('dragstart', (event) => {
+      // disable inner elements messing with drag interaction
+      for (const child of node.children) {
+        child.style.pointerEvents = 'none';
+      }
+      // remember pointer offset for precise drag interaction
+      nodeRelativeOffset.x = event.layerX;
+      nodeRelativeOffset.y = event.layerY;
+      // remember starting position in case user drags out of bounds
+      const rect = node.getBoundingClientRect();
+      nodeStartingPosition.x = rect.x;
+      nodeStartingPosition.y = rect.y;
+    });
+
+    node.addEventListener('dragend', () => {
+      // reenable inner elements
+      for (const child of node.children) {
+        child.style.pointerEvents = '';
+      }
+    });
+
+    node.addEventListener('drag', (event) => {
+      // detect if out of bounds
+      if (!event.clientX || !event.clientY) return;
+      // update position with cursor's current x/y
+      node.style.top = `${event.clientY - nodeRelativeOffset.y}px`;
+      node.style.left = `${event.clientX - nodeRelativeOffset.x}px`;
+    });
+  }
+  // fix "not-allowed" cursor during interaction:
+  document.addEventListener('dragover', (event) => {
+    event.preventDefault();
+  });
+
+  /**
+   * Image gallery logic:
+   */
   const sliderImages = document.querySelectorAll('.hero-slider img');
   const sliderControls = document.querySelectorAll('.hero-slider-control');
   let currentSlide = 0;

--- a/quiz.html
+++ b/quiz.html
@@ -67,7 +67,7 @@
         <p id="randomLineContainer"></p>
       </div>
 
-      <div class="chat">
+      <div class="chat draggable">
         <iframe
           id="twitch-chat-embed"
           src="https://www.twitch.tv/embed/forsen/chat?parent=forsen.site"


### PR DESCRIPTION
PR adds global "draggable" class for any element.
Elements with this class can be moved around using mouse.
Sorry, mobile friends. This does not work with touch events.

For now, the only element which uses this feature is twitch chat frame.